### PR TITLE
Typo

### DIFF
--- a/illu/d/shadow_mask.svg
+++ b/illu/d/shadow_mask.svg
@@ -574,7 +574,7 @@
        id="text22289-7-1"><tspan
          sodipodi:role="line"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.00206px;font-family:'Roboto Mono';-inkscape-font-specification:'Roboto Mono';text-align:center;text-anchor:middle;stroke-width:0.437629"
-         x="166.51392"
+         x="156.51392"
          y="139.54604"
          id="tspan23132-6-6">PHOSPHORUS STRIPS</tspan></text>
     <path

--- a/illu/d/shadow_mask.svg
+++ b/illu/d/shadow_mask.svg
@@ -533,7 +533,7 @@
          id="tspan22287"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.00206px;font-family:'Roboto Mono';-inkscape-font-specification:'Roboto Mono';text-align:center;text-anchor:middle;stroke-width:0.437629"
          x="49.74511"
-         y="59.981548">ELECTON </tspan><tspan
+         y="59.981548">ELECTRON </tspan><tspan
          sodipodi:role="line"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.00206px;font-family:'Roboto Mono';-inkscape-font-specification:'Roboto Mono';text-align:center;text-anchor:middle;stroke-width:0.437629"
          x="49.74511"
@@ -576,7 +576,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.00206px;font-family:'Roboto Mono';-inkscape-font-specification:'Roboto Mono';text-align:center;text-anchor:middle;stroke-width:0.437629"
          x="166.51392"
          y="139.54604"
-         id="tspan23132-6-6">PHOSPORE STRIPS</tspan></text>
+         id="tspan23132-6-6">PHOSPHORUS STRIPS</tspan></text>
     <path
        style="fill:none;stroke:#000000;stroke-width:0.272915;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.272915, 0.272915;stroke-dashoffset:0;stroke-opacity:1"
        d="m 201.92894,102.22719 22.0405,10.8203"

--- a/src/hardware.tex
+++ b/src/hardware.tex
@@ -709,7 +709,7 @@ On the way toward the panel, electrons are filtered through a shadow mask to mak
 
 \begin{figure}[H]
 \draw{shadow_mask}
-\caption*{Electon gun, mask, and slots}
+\caption*{Electron gun, mask, and slots}
 \end{figure}
 
 Slots are not aligned horizontally. When the gun shoots electrons it doesn't really know on which slots they will land. They can hit all in one slot, or two halves of two slots, or other configurations depending on slot density and beam dispersion. 


### PR DESCRIPTION
Small type in "shadow_mask.svg" (Electon for Electron and Phospore for Phosphorus). With the new (slightly) longer text it was necessary to modify the text "Phosphorus strips" position. Also thank you very much for your contributions and also for this book!