### PR TITLE
Replace "velocity" with "speed" in the context of processor performance

### DIFF
--- a/src/hardware.tex
+++ b/src/hardware.tex
@@ -242,7 +242,7 @@ The control system oversees the platform. As a ruler it needs not to excel at a 
 
 \nbdraw{mips}
 
-However, this lack of velocity did not prevent a a plethora of manufacturers from using it as their backbone. On the list of machines adopting the m68k can be found the Atari ST, Amiga, Sega's System 16, Genesis, Sega CD, Apple Macintosh, Sharp X68000, and even SNK's Neo-Geo. It was even IBM's first choice for its PC before production issues allowed the Intel 8088 to prevail\cite{ieee20170630}. 
+However, this lack of speed did not prevent a a plethora of manufacturers from using it as their backbone. On the list of machines adopting the m68k can be found the Atari ST, Amiga, Sega's System 16, Genesis, Sega CD, Apple Macintosh, Sharp X68000, and even SNK's Neo-Geo. It was even IBM's first choice for its PC before production issues allowed the Intel 8088 to prevail\cite{ieee20170630}. 
 
 Performance is not what made the 68000 reign as the prime hardware design choice. The reason this CPU was so successful is because it was a great team player.
 


### PR DESCRIPTION
Velocity, being a vector-valued quantity signifying direction and magnitude, is not really applicable in the context of processor performance, speed I think is better suited here. "performance" would also be applicable.