### PR TITLE
Feature/adpcm fixes

### DIFF
--- a/src/code/adpcm_algo.c
+++ b/src/code/adpcm_algo.c
@@ -11,12 +11,12 @@ int stepSizeIndex = 0; // Initial value (0) points to 16
 int16_t lastSample = 0;
 
 int8_t compress(int16_t sample) {
-  int8_t B3, B2 ,B1, B0; // Bit of the output nibble
+  int8_t B3 = 0, B2 = 0, B1 = 0, B0 = 0; // Bit of the output nibble
 
-  sample >>=4 // Convert from 16-bit to 12-bit
-  int16_t diff = lastSample - sample; 
+  sample >>= 4; // Convert from 16-bit to 12-bit
+  int16_t diff = sample - lastSample; 
 
-  if (diff) < 0) B3 = 1 // Set magnitude sign bit
+  if (diff < 0) B3 = 1; // Set magnitude sign bit
   diff = abs(diff);
 
   int16_t ss = stepSizes[stepSizeIndex]; 
@@ -25,14 +25,11 @@ int8_t compress(int16_t sample) {
   if (diff >= ss/2) B1 = 1, diff -= (ss/2); // Set B1
   if (diff >= ss/4) B0 = 1;                 // Set B0
 
-  int8_t nibble = B3 << 3 | B2 << 2 || B1 << 1 | B0; 
+  int8_t nibble = B3 << 3 | B2 << 2 | B1 << 1 | B0; 
 
   // Keep track of the value upon decompression
   lastSample = decompress(lastSample, nibble, stepSizeIndex); 
 
-  int8_t transIndex = ss/4 * nibble & 0x1) +
-                      ss/2 * nibble & 0x2) +
-                      ss  *  nibble & 0x4) ; 
-  stepSizeIndex += transitionTable[transIndex];
+  stepSizeIndex += transitionTable[nibble & 0x7];
   return nibble;
 }

--- a/src/prog_z80.tex
+++ b/src/prog_z80.tex
@@ -52,21 +52,21 @@ Let's take an example converting a stream of 16-bit PCM to 4-bit ADPCM nibbles.
 The first 16-bit sample has a value of \icode{960} which becomes \icode{60} in 12-bit. With the current step size at 16, ADPCM can only command a delta of + ( 16 + 16/2 + 16/4) = +28 which it encodes in a nibble \icode{0b0111}. The step size index is updated via the transitionTable[\icode{b111}] = 8. The current step size is \icode{34}. 
 
 \subsubsection{Compressing sample 2}
-The second 16-bit sample also has a value of \icode{960} which becomes \icode{60} in 12-bit. Since the latest sample output was 28, ADPCM must somehow encode a difference of 60-28 = 32. ADPCM commands a delta of + ( 0 + 34/2 + 34/4) = +33 which it encodes in a nibble \icode{0b0011}. 
+The second 16-bit sample also has a value of \icode{960} which becomes \icode{60} in 12-bit. Since the latest sample output was 28, ADPCM must somehow encode a difference of 60-28 = 32. ADPCM commands a delta of + ( 0 + 34/2 + 34/4) = +25 which it encodes in a nibble \icode{0b0011}. 
 
-The decompressor will output 28 (its last value) + 33 = 61. It will slightly overshoot the desired value but we can see how the step size has adapted to the delta requested with only two steps. 
+The decompressor will output 28 (its last value) + 25 = 53. We can see how the step size has adapted to the delta requested with only two steps. 
 
 The step size index is updated via 8 (previous value) -1 (transitionTable[\icode{b011}]) = 7. Now the step size is \icode{31}.
 
 \subsubsection{Compressing sample 3}
-The third 16-bit sample has a value of \icode{950} which becomes \icode{56} in 12-bit. Since the latest sample output was 61, ADPCM encodes a difference of 56-61 = -5. ADPCM commands a delta of - (0 + 0 + 31/4) = -7 which it encodes in a nibble \icode{0b1001}. 
+The third 16-bit sample has a value of \icode{950} which becomes \icode{59} in 12-bit. Since the latest sample output was 53, ADPCM encodes a difference of 59-53 = 6. ADPCM commands a delta of + (0 + 0 + 0) = 0 which it encodes in a nibble \icode{0b0000}. 
 
-The decompressor will output 61 (its last value) - 5 = 56. The step size index is updated via 7 (previous value) - 1  (transitionTable[\icode{b001}]) = 6. Now the step size is \icode{28}.
+The decompressor will output 53 (its last value) + 0 = 53. The step size index is updated via 7 (previous value) - 1  (transitionTable[\icode{b000}]) = 6. Now the step size is \icode{28}.
 
 \subsubsection{Compressing sample 4}
-The last 16-bit sample has a value of \icode{160} which becomes \icode{10} in 12-bit. Since the latest sample output was 56, ADPCM encodes a difference of 10-56 = -46. ADPCM commands a delta of - (28 + 28/2 + 0) = -42 which it encodes in a nibble \icode{0b1110}. 
+The last 16-bit sample has a value of \icode{160} which becomes \icode{10} in 12-bit. Since the latest sample output was 53, ADPCM encodes a difference of 10-53 = -43. ADPCM commands a delta of - (28 + 28/2 + 0) = -42 which it encodes in a nibble \icode{0b1110}. 
 
-The decompressor will output 56 (its last value) - 42 = 14. The step size index is updated via 6 (previous value) + 6 (transitionTable[\icode{0b110}]) = 12. Now the step size is \icode{50}.
+The decompressor will output 53 (its last value) - 42 = 11. The step size index is updated via 6 (previous value) + 6 (transitionTable[\icode{0b110}]) = 12. Now the step size is \icode{50}.
 
 Graphing PCM vs ADPCM shows that the decompressed stream "lags" behind upon abrupt changes but catches up aggressively. ADPCM first value is always near zero (+/-28) but it is not audible to players since most samples start with a fade-in. 
 


### PR DESCRIPTION
The ADPCM source code and description contained a number of errors, fix that. I did not update the SVG, but it doesn't seem to use the exact sample values anyway.