### PR TITLE
Fix Fujiwara Tokuro's Japanese name

### DIFF
--- a/src/people.tex
+++ b/src/people.tex
@@ -11,7 +11,7 @@ Many people were mentioned during this book. In the early 90s, Capcom arcade div
 
 \textbf{Nin} (\textbf{Akira Nishitani}, \begin{CJK}{UTF8}{min}西谷 亮\end{CJK}): Joined Capcom in 1985. His nickname, "NiN", is well known since it is associated with high-scores in all the games he planned. Among many other titles, he was a planner (focusing on gameplay) on Forgotten Worlds, Final, and Street Fighter II. He left Capcom in 1995 to found Arika and produced the Street Fighter EX series for his former company.
 
-\textbf{Professor F} / \textbf{Arthur King} (\textbf{Tokuro Fujiwara}, \begin{CJK}{UTF8}{min}藤原 得郎一\end{CJK}): Joined Capcom in 1983 and planned Commando, Ghosts 'n Goblins, and Bionic Commando. He became General Manager in 1988. After working at Capcom for 13 years, he left in 1996 to start his own studio, Whoopee Camp.
+\textbf{Professor F} / \textbf{Arthur King} (\textbf{Tokuro Fujiwara}, \begin{CJK}{UTF8}{min}藤原 得郎\end{CJK}): Joined Capcom in 1983 and planned Commando, Ghosts 'n Goblins, and Bionic Commando. He became General Manager in 1988. After working at Capcom for 13 years, he left in 1996 to start his own studio, Whoopee Camp.
 
 \textbf{Kouichi Yotsui} (\begin{CJK}{UTF8}{min}四井浩一\end{CJK}): Joined Capcom in 1986 and planned the impressive first CPS-1 title, Strider. He left in 1990 and went on to work at Takeru and later Mitchell Corporation. Nowadays, he works as a freelancer.
 


### PR DESCRIPTION
The name should be「藤原 得郎」not「藤原 得郎一」according to

https://en.wikipedia.org/wiki/Tokuro_Fujiwara