### PR TITLE
Bibl: missing closing dquotes, Platinium -> Platinum

### DIFF
--- a/src/bib.tex
+++ b/src/bib.tex
@@ -310,7 +310,7 @@ They were the top decision maker in a Japanese game dev team. Responsible for gi
   2015-06-25
   
      \bibitem{MSM6295_datasheet}
-  \textbf{"MSM6295 datasheet} (by OKI),
+  \textbf{"MSM6295 datasheet"} (by OKI),
   \href{https://fabiensanglard.net/sf2_sound_system/MSM6295.pdf}{link}
   
       \bibitem{smc70tech}
@@ -335,7 +335,7 @@ They were the top decision maker in a Japanese game dev team. Responsible for gi
   2014-09-23
 
         \bibitem{sf2platinium}
-  \textbf{"Street Fighter II Platinium Source Code"} (Ben Torkington),
+  \textbf{"Street Fighter II Platinum Source Code"} (Ben Torkington),
   \href{https://github.com/bentorkington/sf2ww}{link}
   2021-10-10
 


### PR DESCRIPTION
but the bib item still keeps the "platinium" typo in it.
And I have no idea where the 3rd "change" popped out from, it wasn't there on the preview... 8-(