### PR TITLE
Corrected m68k memory for kick harness

### DIFF
--- a/src/hardware.tex
+++ b/src/hardware.tex
@@ -369,7 +369,7 @@ Thanks to the PAL chips enabling/disabling components, the 68000's memory space 
   \texttt{0x800000} & \texttt{0x800007} & 8 B & JAMMA Players Inputs \\
   \texttt{0x800018} & \texttt{0x80001F} & 8 B & JAMMA Dip Switches \\
   \texttt{0x800030} & \texttt{0x800037} & 8 B & JAMMA Coin sensors \\
-  \texttt{0x800176} & \texttt{0x800177} & 1 B & Kick harness \\
+  \texttt{0x800176} & \texttt{0x800177} & 2 B & Kick harness \\
 \toprule    
   \texttt{0x800100} & \texttt{0x80013f} & 64 B & CPS-A registers\\
   \texttt{0x800140} & \texttt{0x80017f} & 64 B & CPS-B registers\\


### PR DESCRIPTION
Looks like there is a mistake in the m68k memory map table for the kick harness. Accordingly to memory addresses, the kick harness size should be 2 bytes and not 1 byte.