### PR TITLE
Some fixes to hardware details

### DIFF
--- a/src/hardware.tex
+++ b/src/hardware.tex
@@ -331,7 +331,7 @@ This is an over-simplification to introduce complexity progressively. We will se
 \subsection{Motorola 68000 Program ROM}
 
 
-The 68000 instructions are provided by eight \icode{27C010} which are 128 Ki $\times$ 8-bit chips. They work like the \icode{65256BLSP-10} except that they have sixteen address lines instead of fifteen (and therefore higher capacity).
+The 68000 instructions are provided by eight \icode{27C010} which are 128 Ki $\times$ 8-bit chips. They work like the \icode{65256BLSP-10} except that they have seventeen address lines instead of fifteen (and therefore higher capacity).
 
 Like the RAM, ROM chips are combined via two-way interleaves to provide 16-bit data. What is peculiar is how the four pairs are arranged to build a memory system with larger capacity.
 

--- a/src/hardware.tex
+++ b/src/hardware.tex
@@ -1477,7 +1477,7 @@ As limiting as it sounds there is a bit of flexibility thanks to a technique kno
 As the CRT cannon progresses down the screen, a sprite unit used above can be reused to draw sprites located below. By changing the configuration during HBLANK, many more than eight sprites can be drawn. This trick was extensively used in games to reach well over 100 sprites on screen.
 
 
-Likewise, by using built-in multiplexing, the Commodore Amiga placed an horizontal limit of 8 pixels for its sprites' width but allowed unlimited height.\index{Sprites Multiplexing!Amiga}
+Likewise, by using built-in multiplexing, the Commodore Amiga placed an horizontal limit of 16 pixels for its sprites' width but allowed unlimited height.\index{Sprites Multiplexing!Amiga}
 
 \subsubsection{Line buffer}
 To scale better and increase the number of sprites supported, hardware designers introduced the concept of line buffers. 


### PR DESCRIPTION
27C010 are 128K ROMs, and have 17 (A0-A16) address lines.