### PR TITLE
Correct typo

### DIFF
--- a/src/hardware.tex
+++ b/src/hardware.tex
@@ -233,7 +233,7 @@ The video system produces a stream of palette addresses. Combined with the palet
 
 
 \section{Control System}\index{Systems!Control}
-The control system oversees the platform. As a ruler it needs not to excel at a specific task but to be able to direct and keep tabs on many components. This is a task tailor-made for the Motorola 68000.
+The control system oversees the platform. As a rule it needs not to excel at a specific task but to be able to direct and keep tabs on many components. This is a task tailor-made for the Motorola 68000.
 
 
 \subsection{Motorola 68000 CPU}\index{Processors!Motorola 68000}


### PR DESCRIPTION
'as a ruler' should read 'as a rule'?