### PR TITLE
Fix some typographic issues

### DIFF
--- a/src/code/adpcm_algo.c
+++ b/src/code/adpcm_algo.c
@@ -11,7 +11,8 @@ int stepSizeIndex = 0; // Initial value (0) points to 16
 int16_t lastSample = 0;
 
 int8_t compress(int16_t sample) {
-  int8_t B3 = 0, B2 = 0, B1 = 0, B0 = 0; // Bit of the output nibble
+  // Bit of the output nibble
+  int8_t B3 = 0, B2 = 0, B1 = 0, B0 = 0;
 
   sample >>= 4; // Convert from 16-bit to 12-bit
   int16_t diff = sample - lastSample; 

--- a/src/gfx.tex
+++ b/src/gfx.tex
@@ -226,7 +226,7 @@ On one hand, the substantial list of extensions and peripherals, totaling nearly
 \subsubsection{Noteworthy capabilities}
 The SMC-70 is notable for being the first computer to allow a 3.5" floppy reader (also invented by Sony in 1981) and its ability to display kanji characters via a ROM extension. 
 
-However, it is really when it comes to graphic capabilities that the machine stood out. Four resolutions were available, ranging from low-resolution 320x200 using sixteen colors up to high-resolution 640x200 in two colors. 
+However, it is really when it comes to graphic capabilities that the machine stood out. Four resolutions were available, ranging from low-resolution 320$\times$200 using sixteen colors up to high-resolution 640$\times$200 in two colors.
 
 The 16 colors mode was particularly interesting to Capcom artists since it was a perfect match to the CPS-1 pen system.
 

--- a/src/gfx.tex
+++ b/src/gfx.tex
@@ -30,7 +30,7 @@ The channels mentioned earlier are now visible. ROM \icode{01} and ROM \icode{02
 
 \nbdraw{build_graph_gfx}
 
-The Street Fighter II board build generates twelve ROMs. Each group stores 2 MiB. Group [1-4] starts at 0x000000, group [10-13] at 0x200000, and ROMs [20-23] at 0x400000. Each chip goes in the matching numbered DIP slot (see page \pageref{boardb_no_chips}).
+The Street Fighter II board build generates twelve ROMs. Each group stores 2 MiB. Group [1--4] starts at 0x000000, group [10--13] at 0x200000, and ROMs [20--23] at 0x400000. Each chip goes in the matching numbered DIP slot (see page \pageref{boardb_no_chips}).
 
 
 

--- a/src/hardware.tex
+++ b/src/hardware.tex
@@ -1217,7 +1217,7 @@ Upon reading, an address is issued to two chips at the same time, but their data
 
 
 \subsection{CPS1 Tilemaps}
-The CPS-1 features three tilemap layers named SCROLL1, SCROLL2, and SCROLL3. They all rely on tilemaps made of 64x64 tiles.
+The CPS-1 features three tilemap layers named SCROLL1, SCROLL2, and SCROLL3. They all rely on tilemaps made of 64$\times$64 tiles.
 
 
 \vfill
@@ -1227,7 +1227,7 @@ The CPS-1 features three tilemap layers named SCROLL1, SCROLL2, and SCROLL3. The
  \end{figure}%
 \pagebreak
 
-SCROLL1 uses tiles of dimensions 8x8 resulting in a total dimension of 512x512. SCROLL2 uses tiles of dimensions 16x16 resulting in a total dimension of 1024x1024. SCROLL3 uses tiles of dimensions 32x32 resulting in a total dimension of 2048x2048.
+SCROLL1 uses tiles of dimensions 8$\times$8 resulting in a total dimension of 512$\times$512. SCROLL2 uses tiles of dimensions 16$\times$16 resulting in a total dimension of 1024$\times$1024. SCROLL3 uses tiles of dimensions 32$\times$32 resulting in a total dimension of 2048$\times$2048.
 
 \index{Colors!Palette page}
 Each tilemap has a maximum capacity of 32 palettes (called a palette page) which any tile can use freely. SCROLLS can be offset ("scrolled", hence their name) by any X or Y value, appear in any order, and be used for any purpose.
@@ -1557,7 +1557,7 @@ With its architecture based on a double sprite framebuffer, Capcom built a power
 
 Up to that point, frustration arose from sprite dimensions (all sprites had to have the same sizes), shapes (mandatory rectangular), and colors (one palette per sprite). 
 
-The CPS-1 lifted these three limitations by abandoning the concept of sprites. The CPS-1 does have a "sprite" layer but it is made of tiles of dimensions 16x16 pixels. Called OBJ (for OBJects) its TILEs can be arranged however an artist requires to build sprites of arbitrary shapes and sizes. 
+The CPS-1 lifted these three limitations by abandoning the concept of sprites. The CPS-1 does have a "sprite" layer but it is made of tiles of dimensions 16$\times$16 pixels. Called OBJ (for OBJects) its TILEs can be arranged however an artist requires to build sprites of arbitrary shapes and sizes.
 
 Like the other layers, OBJ palette page features 32 units which any tile can freely use.
 
@@ -2139,7 +2139,7 @@ All graphics are
 stored together in the same ROMs.
 
 But the hardware knows which part of the ROM space
-is 8x8 tiles, 16x16 tiles, 16x16 spites, 32x32 tiles, and all games tested only
+is 8$\times$8 tiles, 16$\times$16 tiles, 16$\times$16 spites, 32$\times$32 tiles, and all games tested only
 draw tiles if their code falls in the valid range. 
 
 If a tile is out of range, it is replaced by transparent pixels.

--- a/src/prog_68000.tex
+++ b/src/prog_68000.tex
@@ -585,9 +585,9 @@ CPU & M68000 10MHz & M68000 7.16 MHz\\
 RAM & 1MiB & 512 KiB\\
 Max RAM & 4 MiB & 2 MiB\\ 
 Colors  & 65,536 colors (stable) & 4,096 (HAM) \\
-Resolution & 1024×1024 & 736x483 \\
+Resolution & 1024×1024 & 736×483 \\
 % Graphics & 1 sprite plane, 2 bg planes, 4 bitmap planes& \\
-Sprite engine & 128 units, 16x16 tiles & 8 units, 16x16 tiles\\
+Sprite engine & 128 units, 16×16 tiles & 8 units, 16×16 tiles\\
 % Background engine & 2 in 256x256 \\
 VRAM & 1056 KiB & -\\
 Sound & Oki MSM6258 (1 channel)  & 4 channels PCM\\ 
@@ -611,24 +611,24 @@ The \textbf{Bitmap Plane} is particularly well suited to plot pixels and render 
 
 \begin{itemize}[topsep=0pt]
 % \setlength\itemsep{0.2em}
-\item One 512x512 layer with direct 16bpp colors.
-\item Two 512x512 layers with shared 8bpp indexed colors.
-\item Four 512x512 layers with shared 4bpp indexed colors.
-\item One 1024x1024 layer with 4bpp indexed colors.
+\item One 512×512 layer with direct 16bpp colors.
+\item Two 512×512 layers with shared 8bpp indexed colors.
+\item Four 512×512 layers with shared 4bpp indexed colors.
+\item One 1024×1024 layer with 4bpp indexed colors.
 \end{itemize}
 
 The \textbf{Text Plane} is deceptively named. It is also a bitmap plane but it expects values across four bitplanes making it well suited to write large quantities of bits in few operations. A m68k writing a 16-bit word can set 16 pixels which makes text rendering very fast when copying characters from a model. Two modes are available.
 
 \begin{itemize}[topsep=0pt]
-\item One 1024x1024 layer with 4bpp indexed colors.
-\item Four 512x512 layers with 1bpp monochrome.
+\item One 1024×1024 layer with 4bpp indexed colors.
+\item Four 512×512 layers with 1bpp monochrome.
 \end{itemize}
 
 
 The \textbf{TileMap Plane} offers two modes.
 \begin{itemize}[topsep=0pt]
-\item Two 512x512, using 8x8 tiles with 4bpp indexed colors (16 palettes).
-\item One 1024x1024, using 16x16 tiles with 4bpp indexed colors (16 palettes).
+\item Two 512×512, using 8×8 tiles with 4bpp indexed colors (16 palettes).
+\item One 1024×1024, using 16×16 tiles with 4bpp indexed colors (16 palettes).
 \end{itemize}
 
 The \textbf{Sprite Plane} is a sprite layer allowing 128 sprites on-screen (with a max of 32 sprites per scanline). Each sprite uses 4bpp indexed color (16 palettes).
@@ -722,11 +722,11 @@ All these clues strongly suggest the SHARP X68000 was limited to writing/testing
 
 
 \subsection{Ports Analysis: Ghouls 'n Ghosts (1994)}
-Ghouls 'n Ghosts was released in 1994, six years after the arcade version. It is noteworthy for its low RAM requirements of 2MiB RAM and its resolution of 512x512.
+Ghouls 'n Ghosts was released in 1994, six years after the arcade version. It is noteworthy for its low RAM requirements of 2MiB RAM and its resolution of 512$\times$512.
 
 It is considered a "perfect port" because of its GFX faithfulness to the CPS-1 version. All the enemies, levels, and weapons are there, rendered with the correct rich colors. 
 
-The Tilemap plane is not used at all since the background lives in two software rendered 512x512 Bitmap layers using a shared 8-bit indexed colors palette. The Text layer is also fully software rendered in 1024x1024 16 colors despite the CPU cost of plotting pixels in that mode. The cost and low number of colors makes it a good fit for rendering the GUI elements.
+The Tilemap plane is not used at all since the background lives in two software rendered 512$\times$512 Bitmap layers using a shared 8-bit indexed colors palette. The Text layer is also fully software rendered in 1024$\times$1024 16 colors despite the CPU cost of plotting pixels in that mode. The cost and low number of colors makes it a good fit for rendering the GUI elements.
 
 \begin{figure}[H]
 \img{x68k_gg_scrw.png}
@@ -744,28 +744,28 @@ The rain effect is replicated as seen on page \pageref{gg_rain} via the Text lay
 \begin{minipage}[t]{0.49\linewidth}
   \begin{figure}[H]
   \img{x68k_gg_bitmap1.png}
-  \caption*{512x512 Graphic Plane Page 0}
+  \caption*{512$\times$512 Graphic Plane Page 0}
   \end{figure}
 \end{minipage}%
 \hfill
 \begin{minipage}[t]{0.49\linewidth}
   \begin{figure}[H]
   \img{x68k_gg_bitmap2.png}
-  \caption*{512x512 Graphic Plane Page 1}
+  \caption*{512$\times$512 Graphic Plane Page 1}
   \end{figure}
 \end{minipage}%
 
 \begin{minipage}[t]{0.49\linewidth}
   \begin{figure}[H]
   \img{x68k_gg_text.png}
-  \caption*{Portion of 1024x1024 Text Layer}
+  \caption*{Portion of 1024$\times$1024 Text Layer}
   \end{figure}
 \end{minipage}%
 \hfill
 \begin{minipage}[t]{0.49\linewidth}
    \begin{figure}[H]
   \img{x68k_gg_sprites.png}
-  \caption*{512x512 Sprite Layer}
+  \caption*{512$\times$512 Sprite Layer}
   \end{figure}
 \end{minipage}%
 
@@ -798,28 +798,28 @@ The YM2151 let music be close to the arcade version but without samples. The OKI
 \begin{minipage}[t]{0.49\linewidth}
   \begin{figure}[H]
   \img{x68k_ff_bitmap1.png}
-  \caption*{512x512 Graphic Plane Page 0}
+  \caption*{512$\times$512 Graphic Plane Page 0}
   \end{figure}
 \end{minipage}%
 \hfill
 \begin{minipage}[t]{0.49\linewidth}
   \begin{figure}[H]
   \img{x68k_ff_bitmap2.png}
-  \caption*{512x512 Graphic Plane Page 1}
+  \caption*{512$\times$512 Graphic Plane Page 1}
   \end{figure}
 \end{minipage}%
 
 \begin{minipage}[t]{0.49\linewidth}
   \begin{figure}[H]
   \img{x68k_ff_text.png}
-  \caption*{Portion of 1024x1024 Text Layer}
+  \caption*{Portion of 1024$\times$1024 Text Layer}
   \end{figure}
 \end{minipage}%
 \hfill
 \begin{minipage}[t]{0.49\linewidth}
    \begin{figure}[H]
   \img{x68k_ff_sprites.png}
-  \caption*{512x512 Sprite Layer}
+  \caption*{512$\times$512 Sprite Layer}
   \end{figure}
 \end{minipage}%
 
@@ -841,7 +841,7 @@ To manage this problem, developers started by cutting out one minion (blue Jake)
 
 Since it was still too many tiles, they resorted to enabling (for the intro only) the Tilemap plane. Five out of the six barrels are drawn as tilemap in the Tilemap 0.
 
-Since a tilemap is a simple grid of tiles with no concept of sprites and overlap, special 8x8 tiles were generated where columns of barrels are pre-overlapped.
+Since a tilemap is a simple grid of tiles with no concept of sprites and overlap, special 8$\times$8 tiles were generated where columns of barrels are pre-overlapped.
 
 Things get messy when animation must occur. To allow the barrels to be broken into pieces, the engine exploits the timing of enemies fleeing. First when Damned leaves, then when Dug retires, rows of barrels are progressively migrated out of the tilemap layer into the sprite layer. 
 
@@ -909,28 +909,28 @@ Notice the noise in the Graphic layers, the bottom part in Page 0 and the top pa
 \begin{minipage}[t]{0.49\linewidth}
   \begin{figure}[H]
   \img{x68k_sf2ce_bitmap0.png}
-  \caption*{512x512 Graphic Plane Page 0}
+  \caption*{512$\times$512 Graphic Plane Page 0}
   \end{figure}
 \end{minipage}%
 \hfill
 \begin{minipage}[t]{0.49\linewidth}
   \begin{figure}[H]
   \img{x68k_sf2ce_bitmap1.png}
-  \caption*{512x512 Graphic Plane Page 1}
+  \caption*{512$\times$512 Graphic Plane Page 1}
   \end{figure}
 \end{minipage}%
 
 \begin{minipage}[t]{0.49\linewidth}
   \begin{figure}[H]
   \img{x68k_sf2ce_text.png}
-  \caption*{Portion of 1024x1024 Text Layer}
+  \caption*{Portion of 1024$\times$1024 Text Layer}
   \end{figure}
 \end{minipage}%
 \hfill
 \begin{minipage}[t]{0.49\linewidth}
    \begin{figure}[H]
   \img{x68k_sf2ce_sprites.png}
-  \caption*{512x512 Sprite Layer}
+  \caption*{512$\times$512 Sprite Layer}
   \end{figure}
 \end{minipage}%
 
@@ -966,7 +966,7 @@ This reduces overdraw when the Page 1 cyclist crosses the screen and goes over t
 \setlength{\intextsep}{0pt}
 \begin{figure}[H]
 \img{x68k_sf2ce2_bitmap0.png}
-\caption*{512x512 Graphic Plane Page 0}
+\caption*{512$\times$512 Graphic Plane Page 0}
 \end{figure}
 \end{minipage}%
 \hfill
@@ -974,21 +974,21 @@ This reduces overdraw when the Page 1 cyclist crosses the screen and goes over t
 \setlength{\intextsep}{0pt}
   \begin{figure}[H]
   \img{x68k_sf2ce2_bitmap1.png}
-  \caption*{512x512 Graphic Plane Page 1}
+  \caption*{512$\times$512 Graphic Plane Page 1}
   \end{figure}
 \end{minipage}%
 
 \begin{minipage}[t]{0.49\linewidth}
   \begin{figure}[H]
   \img{x68k_sf2ce2_text.png}
-  \caption*{Portion of 1024x1024 Text Layer}
+  \caption*{Portion of 1024$\times$1024 Text Layer}
   \end{figure}
 \end{minipage}%
 \hfill
 \begin{minipage}[t]{0.49\linewidth}
    \begin{figure}[H]
   \img{x68k_sf2ce2_sprites.png}
-  \caption*{512x512 Sprite Layer}
+  \caption*{512$\times$512 Sprite Layer}
   \end{figure}
 \end{minipage}%
 

--- a/src/prog_z80.tex
+++ b/src/prog_z80.tex
@@ -182,9 +182,9 @@ The calling functions from ASM to C require using \icode{\_} prefixed symbols.
 \index{Interrupts!Programming z80}
 In order to interact with the latches properly but also be able to keep track of wall-time, the z80 needs to be interrupted regularly. Zilog's CPU does features a timer RFSH but it is intended for DRAM refresh (which the sound system does not feature anyway).
 
-Instead the interrupts are triggered by the YM2151, thanks to its two internal timers. Timer A is a 10-bit counter while Timer B is an 8-bit counter. For a YM2151 running at 3,579Hz, the trigger formula is 64 * (1024 - value) / 3579.
+Instead the interrupts are triggered by the YM2151, thanks to its two internal timers. Timer A is a 10-bit counter while Timer B is an 8-bit counter. For a YM2151 running at 3,579Hz, the trigger formula is 64 $\times$ (1024 - value) / 3579.
 
-Setting the Timer A to \icode{800} will result in an interrupt 64 * (1024 - 800) / 3579 = 4ms later. When the YM2151 counter reaches zero, it asserts a line connected to the z80 \icode{INT} line which makes the CPU jump to address \icode{0x38}.
+Setting the Timer A to \icode{800} will result in an interrupt 64 $\times$ (1024 - 800) / 3579 = 4ms later. When the YM2151 counter reaches zero, it asserts a line connected to the z80 \icode{INT} line which makes the CPU jump to address \icode{0x38}.
 
 \lstinputlisting[style=CStyle]{src/code/z80/interrupts.c}
 

--- a/src/programing.tex
+++ b/src/programing.tex
@@ -124,7 +124,7 @@ To avoid these, the z80 commits to disregard a latch content if its content did 
 \caption*{m68k interrupt system}
 \end{figure}
 
-This introduces an ultimate problem. It is not possible for the m68k CPU to send the same byte twice in a row. To work around this, the writer commits on never writing the same byte twice which is done via a no-op byte (0xFF) written after every byte.
+This introduces an ultimate problem. It is not possible for the m68k CPU to send the same byte twice in a row. To work around this, the writer commits on never writing the same byte twice which is done via a no-op byte (\icode{0xFF}) written after every byte.
 
 
 


### PR DESCRIPTION
Each commit fixes some typographic issues I found when going through the book (see the commit message for slightly more details).

With this PR AFAICT all "x"s and "*"s should now have been replaced by the dedicated multiplication glyph (the ones in the `\icode` sections have been left out because Latex doesn't seem to like them there).