### PR TITLE
Fix m68k bus width

### DIFF
--- a/src/hardware.tex
+++ b/src/hardware.tex
@@ -263,7 +263,7 @@ While other CPUs used small address registers resulting in the infamous segmente
 
 The 68000 is brought to life via its clock (\icode{CLK}), +5V (\icode{VCC}), and Ground (\icode{VSS}) pins.
 
-The bus is made of \icode{D0-D7} for data and \icode{A0-A15} for addresses while address ACK (\icode{AS}), Read/Write (\icode{R/W}), \icode{UDS}, \icode{LDS}, and Data ACK \icode{DTACK} are bus control pins.
+The bus is made of \icode{D0-D15} for data and \icode{A0-A23} for addresses while address ACK (\icode{AS}), Read/Write (\icode{R/W}), \icode{UDS}, \icode{LDS}, and Data ACK \icode{DTACK} are bus control pins.
 
 
 Arbitration to allow peripherals to master the bus is done with Bus Request (\icode{BR}),  Bus Grant (\icode{BG}) and Bus Grant ACK (\icode{GBA-K}) lines.


### PR DESCRIPTION
The m68k has 16 pins for data and 24 pins for the address.

Joyeux Noël ! 🙂 
