### PR TITLE
Minor typo fixes

### DIFF
--- a/src/code/68000/cps1-2.lk
+++ b/src/code/68000/cps1-2.lk
@@ -2,14 +2,14 @@ SECTIONS {
 
   .text : {
     *(.text)
-    _etext = . ; 
+    _etext = . ;
     . = ALIGN(4);
   } @>@ rom
 
   .data : {
     _data = . ;     // Start of .data marker
     *(.data)
-    _edata = . ;    // End  of .data marker
+    _edata = . ;    // End   of .data marker
     . = ALIGN(4);
   } @>@ rom @AT>@ ram   // LMA = rom but VMA = ram
 

--- a/src/code/68000/init_vars.c
+++ b/src/code/68000/init_vars.c
@@ -1,5 +1,5 @@
 // These are defined by the linker via the linker script
-extern char _etext _data, _edata, _bss, _ebss;
+extern char _etext, _data, _edata, _bss, _ebss;
 
 char *src = &_etext;
 char *dst = &_data;

--- a/src/prog_68000.tex
+++ b/src/prog_68000.tex
@@ -214,46 +214,46 @@ In Street Fighter 2, DIP B is used to configure the difficulty level of the game
 
 
 
- % \href{https://github.com/originalgrego/FinalFightAE-Source/blob/master/docs/known_addresses.txt}
- % \begin{figure}[H]
+% \href{https://github.com/originalgrego/FinalFightAE-Source/blob/master/docs/known_addresses.txt}
+% \begin{figure}[H]
 \begin{tabularx}{\textwidth}{Xllr}
-  \toprule    
-  \textbf{Label } & \textbf{ Memory Area }  & \textbf{Address } & \textbf{Mask } \\               
-  \toprule   
-  
-    \texttt{P1\_KEY\_3} & JAMMA Players Inputs &    \texttt{0x800000} &  \texttt{0b01000000}    \\ 
-      \texttt{P1\_KEY\_2} & JAMMA Players Inputs &  \texttt{0x800000} &  \texttt{0b00100000}    \\  	
-    \texttt{P1\_KEY\_1} & JAMMA Players Inputs &    \texttt{0x800000} &  \texttt{0b00010000}    \\     
-  \texttt{P\_UP}    & JAMMA Players Inputs &        \texttt{0x800000} &  \texttt{0b00001000}    \\     
-  \texttt{P1\_DOWN} & JAMMA Players Inputs &  \texttt{0x800000} &  \texttt{0b00000100}    \\     
-  \texttt{P1\_LEFT} & JAMMA Players Inputs &  \texttt{0x800000} &  \texttt{0b00000010}    \\     
-  \texttt{P1\_RIGHT} & JAMMA Players Inputs &  \texttt{0x800000} &  \texttt{0b00000001}    \\     
- 
-  \toprule   
-    \texttt{P2\_KEY\_3} & JAMMA Players Inputs &  \texttt{0x800001}    &  \texttt{0b01000000}    \\     
-  \texttt{P2\_KEY\_2} & JAMMA Players Inputs &  \texttt{0x800001}    &    \texttt{0b00100000}    \\     
-  \texttt{P2\_KEY\_1} & JAMMA Players Inputs &  \texttt{0x800001}    &    \texttt{0b00010000}    \\    
-  \texttt{P2\_UP}    & JAMMA Players Inputs &  \texttt{0x800001}    &     \texttt{0b00001000}    \\     
-  \texttt{P2\_DOWN} & JAMMA Players Inputs &  \texttt{0x800001}    &      \texttt{0b00000100}    \\     
-  \texttt{P2\_LEFT} & JAMMA Players Inputs &  \texttt{0x800001}    &      \texttt{0b00000010}    \\     
-  \texttt{P2\_RIGHT} & JAMMA Players Inputs &  \texttt{0x800001}    &     \texttt{0b00000001}    \\     
+  \toprule
+  \textbf{Label } & \textbf{ Memory Area }  & \textbf{Address } & \textbf{Mask } \\
+  \toprule
 
-  \toprule   
-  \texttt{SERVICE} & JAMMA Coins &  \texttt{0x800018}       &     \texttt{0b01000000}    \\ 
-   \texttt{P2\_START} & JAMMA Coins &  \texttt{0x800018}   &      \texttt{0b00100000}    \\ 
-   \texttt{P1\_START} & JAMMA Coins &  \texttt{0x800018}   &      \texttt{0b00010000}    \\   
-     \texttt{COIN2\_P2} & JAMMA Coins &  \texttt{0x800018}    &   \texttt{0b00000010}    \\  
-   \texttt{COIN\_P1} & JAMMA Coins &  \texttt{0x800018}       &   \texttt{0b00000001}    \\      
-     
+  \texttt{P1\_KEY\_3} & JAMMA Players Inputs &    \texttt{0x800000} &  \texttt{0b01000000}    \\
+  \texttt{P1\_KEY\_2} & JAMMA Players Inputs &  \texttt{0x800000} &  \texttt{0b00100000}    \\
+  \texttt{P1\_KEY\_1} & JAMMA Players Inputs &    \texttt{0x800000} &  \texttt{0b00010000}    \\
+  \texttt{P1\_UP}    & JAMMA Players Inputs &        \texttt{0x800000} &  \texttt{0b00001000}    \\
+  \texttt{P1\_DOWN} & JAMMA Players Inputs &  \texttt{0x800000} &  \texttt{0b00000100}    \\
+  \texttt{P1\_LEFT} & JAMMA Players Inputs &  \texttt{0x800000} &  \texttt{0b00000010}    \\
+  \texttt{P1\_RIGHT} & JAMMA Players Inputs &  \texttt{0x800000} &  \texttt{0b00000001}    \\
 
-    \toprule   
-    \texttt{DIP1} & JAMMA DIPs &  \texttt{0x80001A}    &  \texttt{0bXXXXXXXX}    \\      
-    \texttt{DIP2} & JAMMA DIPs &  \texttt{0x80001C}    &  \texttt{0bXXXXXXXX}    \\      
-    \texttt{DIP2} & JAMMA DIPs &  \texttt{0x80001E}    &  \texttt{0bXXXXXXXX}    \\      
-  \toprule   
+  \toprule
+  \texttt{P2\_KEY\_3} & JAMMA Players Inputs &  \texttt{0x800001}    &  \texttt{0b01000000}    \\
+  \texttt{P2\_KEY\_2} & JAMMA Players Inputs &  \texttt{0x800001}    &    \texttt{0b00100000}    \\
+  \texttt{P2\_KEY\_1} & JAMMA Players Inputs &  \texttt{0x800001}    &    \texttt{0b00010000}    \\
+  \texttt{P2\_UP}    & JAMMA Players Inputs &  \texttt{0x800001}    &     \texttt{0b00001000}    \\
+  \texttt{P2\_DOWN} & JAMMA Players Inputs &  \texttt{0x800001}    &      \texttt{0b00000100}    \\
+  \texttt{P2\_LEFT} & JAMMA Players Inputs &  \texttt{0x800001}    &      \texttt{0b00000010}    \\
+  \texttt{P2\_RIGHT} & JAMMA Players Inputs &  \texttt{0x800001}    &     \texttt{0b00000001}    \\
+
+  \toprule
+  \texttt{SERVICE} & JAMMA Coins &  \texttt{0x800018}       &     \texttt{0b01000000}    \\
+  \texttt{P2\_START} & JAMMA Coins &  \texttt{0x800018}   &      \texttt{0b00100000}    \\
+  \texttt{P1\_START} & JAMMA Coins &  \texttt{0x800018}   &      \texttt{0b00010000}    \\
+  \texttt{COIN\_P2} & JAMMA Coins &  \texttt{0x800018}    &   \texttt{0b00000010}    \\
+  \texttt{COIN\_P1} & JAMMA Coins &  \texttt{0x800018}       &   \texttt{0b00000001}    \\
+
+
+  \toprule
+  \texttt{DIP1} & JAMMA DIPs &  \texttt{0x80001A}    &  \texttt{0bXXXXXXXX}    \\
+  \texttt{DIP2} & JAMMA DIPs &  \texttt{0x80001C}    &  \texttt{0bXXXXXXXX}    \\
+  \texttt{DIP2} & JAMMA DIPs &  \texttt{0x80001E}    &  \texttt{0bXXXXXXXX}    \\
+  \toprule
 \end{tabularx}
 % \caption*{Input bit layouts}
-% \end{figure}  
+% \end{figure}
 
 \subsection{Drawing on screen}
 Requesting tiles to be drawn consists of first describing the layout in GFXRAM, then setting the palettes, and finally writing to the CPS-A and CPS-B registers to point them to "where is the data".


### PR DESCRIPTION
Hi,

Here are a handful of minor typo fixes:
- input names in table (P_UP -> P1_UP / COIN2_P2 -> COIN_P2) (reformatted the table to be more clean, hopefully that won't mess anything up with LATEX)
- missing comma in init_vars.c
- comment alignment in cps1-2.lk

Thanks for another great book!

Cheers,

Rom
