### PR TITLE
Fixed small typo in gfx.tex

### DIFF
--- a/src/gfx.tex
+++ b/src/gfx.tex
@@ -451,7 +451,7 @@ A sprite is a collection of tiles with rectangular boundaries. As we will see in
 
  \begin{figure}[H]
 \nbdraw{honda_alloc1}
-\caption*{Honda has a Sprite}
+\caption*{Honda as a Sprite}
 \end{figure}
 
 While it is convenient to be able to use a single command and the best way to render a set of mostly opaque tiles, it is inefficient. A set of tiles where many are transparent not only wastes precious storage space in the GFXROM, it also counts against the CPS-A/CPS-B limit of 256 tiles per frame.


### PR DESCRIPTION
On Page 162 Honda's sprite had the caption "Honda has a Sprite", I believe this is "Honda as a Sprite" (like on page 163 with shape).

Also I'm curious on page 146 on "Ryu reconstructed sheet": The heads at `0xA6` and `0xC02`, are those used in the credit scene? (like on page 159?) :) 