### PR TITLE
Fix various typos and grammatical errors from pg. 121 to the end

### DIFF
--- a/src/gfx.tex
+++ b/src/gfx.tex
@@ -1,5 +1,5 @@
 \chapter{GFX System}
-Since the graphic pipeline of the CPS-1 is hard-coded in the silicon of the CPS-A and CPS-B, there is no code to write and nothing to compile. 
+Since the graphics pipeline of the CPS-1 is hard-coded in the silicon of the CPS-A and CPS-B, there is no code to write and nothing to compile. 
 
 \begin{figure}[H]
 \sdraw{1.0}{gfx_arch}

--- a/src/hardware.tex
+++ b/src/hardware.tex
@@ -2029,7 +2029,7 @@ Capcom's response was a two-way verification. The hardware could be actively use
 \subsection{The Ever Changing CPS-B}
 The heart of the protection system is the CPS-B. The core idea is to make it behave differently depending on the game it is supposed to run.
 
-To this effect, twenty-five versions the CPS-B exist\cite{mame_cps1_video}, sometimes differing between revision of the same game\cite{cpsBNumbers}.
+To this effect, twenty-five versions of the CPS-B exist\cite{mame_cps1_video}, sometimes differing between revisions of the same game\cite{cpsBNumbers}.
 
 
 \begin{figure}[H]

--- a/src/prog_68000.tex
+++ b/src/prog_68000.tex
@@ -958,9 +958,9 @@ When fighting occurs in China, the Text layer is not used for Sprite decoration 
 
 
 \subsection{Saving Further 68000 Cycles}
-If we look closely at Page 0 and 1, we see that the background is split. The alley is on Page 2 while the rest is on Page 1, which is surprising since no parallax effect exists (they are on the same plane). 
+If we look closely at Page 0 and 1, we see that the background is split. The alley is on Page 1 while the rest is on Page 0, which is surprising since no parallax effect exists (they are on the same plane). 
 
-This reduces overdraw when the Page 1 cyclist crosses the screen and goes over the other cyclist in the back alley, saving a few CPU cycles.
+This reduces overdraw when the Page 0 cyclist crosses the screen and goes over the other cyclist in the back alley, saving a few CPU cycles.
 
 \begin{minipage}[t]{0.49\linewidth}
 \setlength{\intextsep}{0pt}

--- a/src/prog_68000.tex
+++ b/src/prog_68000.tex
@@ -10,7 +10,7 @@ While the latch toward the Sound system is a small API surface, the GFX API is h
 
 To our advantage, the Motorola 68000 is a target supported by the \textbf{G}NU \textbf{C}ompiler \textbf{C}ollection (GCC). This suite features a much more powerful linker script system than \icode{sdcc} which helps considerably to solve the memory mapping requirements.
 
-All stages of the build graph rely on tools provided by GNU GCC. Compiling \icode{.c} code to \icode{.obj} is done via the \icode{gcc} compiler. Assembling \icode{.s} files to \icode{.obj} files is taken care of by the \icode{as} assembler . Finally, the \icode{ld} linker combines all \icode{.obj} together into raw instructions. 
+All stages of the build graph rely on tools provided by GNU GCC. Compiling \icode{.c} code to \icode{.obj} is done via compiler \icode{gcc}. Assembling \icode{.s} files to \icode{.obj} files is taken care of by assembler \icode{as}. Finally, linker \icode{ld} combines all \icode{.obj} together into raw instructions. 
 
 
 \nbdraw{build_graph_ctrl}
@@ -776,7 +776,7 @@ The rain effect is replicated as seen on page \pageref{gg_rain} via the Text lay
 
 Final Fight was released in 1992, three years after the arcade version. Like the Ghouls'n Ghosts port, the game managed to ship on two 5.25-inch 1.2 MiB floppies.
 
-The graphics renderer uses the same trade off used by Ghouls 'n Ghosts where usage of Tilemap plane is sacrificed in favor of the ability to feed the Sprite layer with tiles. 
+The graphics renderer uses the same trade off used by Ghouls 'n Ghosts where usage of the Tilemap plane is sacrificed in favor of the ability to feed the Sprite layer with tiles. 
 
 Two bitmap layers are used for background elements while the Text layer is used for GUI elements. All these layers are rendered in software with a draw cost amortized thanks to hardware scrolling.
 

--- a/src/prog_68000.tex
+++ b/src/prog_68000.tex
@@ -776,11 +776,11 @@ The rain effect is replicated as seen on page \pageref{gg_rain} via the Text lay
 
 Final Fight was released in 1992, three years after the arcade version. Like the Ghouls'n Ghosts port, the game managed to ship on two 5.25-inch 1.2 MiB floppies.
 
-The graphics renderer uses the same trade off used by Ghouls 'n Ghosts where usage of the Tilemap plane is sacrificed in favor of the ability to feed the Sprite layer with tiles. 
+The graphics renderer uses the same trade-off used by Ghouls 'n Ghosts where usage of the Tilemap plane is sacrificed in favor of the ability to feed the Sprite layer with tiles. 
 
 Two bitmap layers are used for background elements while the Text layer is used for GUI elements. All these layers are rendered in software with a draw cost amortized thanks to hardware scrolling.
 
-The port of Final Fight to X68000 is close to the arcade version but is not considered "perfect" because of missing graphics elements and color discrepancies. 
+The Final Fight X68000 port is close to the arcade version but is not considered "perfect" because of missing graphics elements and color discrepancies. 
 
 
 \begin{figure}[H]
@@ -788,7 +788,7 @@ The port of Final Fight to X68000 is close to the arcade version but is not cons
 \caption*{Final Fight on X68000}
 \end{figure}
 
-The number of characters on screen was restricted to 7 which was less than the arcade version where up to 13 were visible. In this case, both the 32 KiB VRAM and the 128 tiles limits were the limiting factor since no multiplexing was possible with free roaming characters.
+The number of characters on screen was capped to 7 whereas the arcade version could have up to 13 visible. In this case, both the 32 KiB VRAM and the 128 tiles limits were the limiting factor since no multiplexing was possible with free roaming characters.
 
 The Sprite sandwich trick (page \pageref{finalfight_trick}), where parts of the staircase appear in front of the Sprite is done with a special blending mode were the MSBs gives precedence over the Sprite layer. This leaves 7bpp for the color indexes and the Background ends up using 128 colors instead of 256. In other levels, this blending mode is not used so the Bitmap layers go back to using 8bpp for a total of 256 colors available.
 

--- a/src/prog_68000.tex
+++ b/src/prog_68000.tex
@@ -10,7 +10,7 @@ While the latch toward the Sound system is a small API surface, the GFX API is h
 
 To our advantage, the Motorola 68000 is a target supported by the \textbf{G}NU \textbf{C}ompiler \textbf{C}ollection (GCC). This suite features a much more powerful linker script system than \icode{sdcc} which helps considerably to solve the memory mapping requirements.
 
-All stages of the build graph rely on tools provided by GNU GCC. Compiling \icode{.c} code to \icode{.obj} is done via \icode{gcc} compiler. Assembling \icode{.s} files to \icode{.obj} files is taken care of by \icode{as} assembler . Finally, the \icode{ld} linker combines all \icode{.obj} together into raw instructions. 
+All stages of the build graph rely on tools provided by GNU GCC. Compiling \icode{.c} code to \icode{.obj} is done via the \icode{gcc} compiler. Assembling \icode{.s} files to \icode{.obj} files is taken care of by the \icode{as} assembler . Finally, the \icode{ld} linker combines all \icode{.obj} together into raw instructions. 
 
 
 \nbdraw{build_graph_ctrl}
@@ -33,7 +33,7 @@ All other slots except for one (offset \icode{26}) point to a no-op routine.
 
 \section{Auto-Interrupt}
 \index{Interrupts!Programming 68000}
-The 68000 has multiple interrupt modes. In its most complex form, \icode{IPL0}, \icode{IPL1}, and \icode{IPL2} encode a level of interrupt and the interrupt ID is retrieved via an external interrupt controller. This would be over-kill for the task at hand.
+The 68000 has multiple interrupt modes. In its most complex form, \icode{IPL0}, \icode{IPL1}, and \icode{IPL2} encode a level of interrupt and the interrupt ID is retrieved via an external interrupt controller. This would be overkill for the task at hand.
 
 A simpler mode, auto-vector, makes the CPU jump directly based on the three IPL lines' state. Three lines are treated as bits giving a value within [0,7], which is used to look up the "vector table" starting at offset \icode{24}.
 
@@ -41,7 +41,7 @@ The 3-bit scheme uses \icode{IPL0} for bit 0, \icode{IPL1} for bit 1, and \icode
 
 \lstinputlisting[style=m68kStyle]{src/code/68000/crt1.s}
 
-The last piece of the \icode{\_boot} function sets up auto-vector mode and jump to \icode{main}.
+The last piece of the \icode{\_boot} function sets up auto-vector mode and jumps to \icode{main}.
 
 \lstinputlisting[style=m68kStyle]{src/code/68000/crt2.s}
 
@@ -249,7 +249,7 @@ In Street Fighter 2, DIP B is used to configure the difficulty level of the game
   \toprule
   \texttt{DIP1} & JAMMA DIPs &  \texttt{0x80001A}    &  \texttt{0bXXXXXXXX}    \\
   \texttt{DIP2} & JAMMA DIPs &  \texttt{0x80001C}    &  \texttt{0bXXXXXXXX}    \\
-  \texttt{DIP2} & JAMMA DIPs &  \texttt{0x80001E}    &  \texttt{0bXXXXXXXX}    \\
+  \texttt{DIP3} & JAMMA DIPs &  \texttt{0x80001E}    &  \texttt{0bXXXXXXXX}    \\
   \toprule
 \end{tabularx}
 % \caption*{Input bit layouts}
@@ -406,7 +406,7 @@ Starfields were used so little that the bytecode mapper was removed altogether f
 
 
 \paragraph{Priority mask}
-These four registers control the precedence of pens belonging to the layer behind the OBJ layer. A tile can be assigned to one priority group within a choice of four ranging within\icode{[0-3]}. A group tags pens in the tile palette to be drawn with higher priority via a 16-bit bitfield mask. Marked pens a drawn above OBJs pens.
+These four registers control the precedence of pens belonging to the layer behind the OBJ layer. A tile can be assigned to one priority group within a choice of four ranging within\icode{[0-3]}. A group tags pens in the tile palette to be drawn with higher priority via a 16-bit bitfield mask. Marked pens are drawn above OBJs pens.
 
 
 
@@ -647,7 +647,7 @@ An even more impressive feat from the CRT compositor is that all layers of each 
 
 The numerous plane capabilities made the X68000 a versatile instrument able to excel at a wide range of tasks, from simple text editing to demanding raytracing. 
 
-Video games were obviously a strength of the machine thanks to its Background and Sprite layers although, as we will see, developers did not employ resources as one would expect.
+Video games were obviously a strength of the machine thanks to its Background and Sprite layers. Although, as we will see, developers did not employ resources as one would expect.
 
 
 
@@ -681,9 +681,9 @@ If the Motorola 68000 CPU and the YM2151 present in both machines are identical,
 
 The sound chip is an OKI but it is "only" a MSM6258. Although it works alike the MSM6296 with ADPCM, it features only one channel which severely impacts how rich the sound effects and music systems can be.
 
-The sprite system is, at first sight, weaker than the CPS-1 since the number of tiles displayable is half (128 instead of 256). But the X68000's  access to raster effect allowed multiplexing (the Sprite Doubler by Koichi Yoshida\cite{x68000spritedoubler}) bringing the upper limit to 512 sprites!\index{Sprites Multiplexing!X68000}
+The sprite system is, at first sight, weaker than the CPS-1 since the number of tiles displayable is half (128 instead of 256). But the X68000's access to raster effects allowed multiplexing (the Sprite Doubler by Koichi Yoshida\cite{x68000spritedoubler}) bringing the upper limit to 512 sprites!\index{Sprites Multiplexing!X68000}
 
-Lastly, the X68000 floppy storage resulted in slow loading time compared to the CPS-1 ROM. To solve this issue, developers used as much RAM as available, going as far as loading the whole floppies during startup if the capacity of the X68000 allowed it.
+Lastly, the X68000 floppy storage resulted in slow loading time compared to the CPS-1 ROM. To solve this issue, developers used as much RAM as available, going as far as loading whole floppies during startup if the capacity of the X68000 allowed it.
 
 
 
@@ -710,7 +710,7 @@ A definitive answer about the viability of the X68000 as a development station c
 \caption*{X68000 Ports of CPS-1 games by Capcom}
 \end{figure}
 
-An analysis methodology shared by Upsilandre\cite{x68k_games_analysis}, leveraging XM6 Pro-68k emulator, shows that the GFX rendering architecture of these titles exhibits no pattern of an emulation layer. On the contrary, the GFX renderers are tailor-made and rely heavily on CPU tricks. 
+An analysis methodology shared by Upsilandre\cite{x68k_games_analysis}, leveraging the XM6 Pro-68k emulator, shows that the GFX rendering architecture of these titles exhibits no pattern of an emulation layer. On the contrary, the GFX renderers are tailor-made and rely heavily on CPU tricks. 
 
 \begin{trivia}
 The stress on the 68000 is confirmed by Ghouls 'n Ghosts manual which recommends a 16MHz CPU and warns about slowdown on a 10MHz 68000.
@@ -734,7 +734,7 @@ The Tilemap plane is not used at all since the background lives in two software 
 \end{figure}
 
 
-Notice the vertical "cut" in the right of Bitmap plane Pages 0 and 1. This artifact reveals the wraparound resulting from hardware scrolling these two layers. This technique allows the CPU to render only new portion of the background. 
+Notice the vertical "cut" in the right of Bitmap plane Pages 0 and 1. This artifact reveals the wraparound resulting from hardware scrolling these two layers. This technique allows the CPU to render only new portions of the background. 
 
 The Sprite layer contains more than sprites. While rendering the wind blowing in the grass only required swapping tile ID on CPS-1, the X68000 could not plot that many pixels in the Bitmap layers. Promoting blades to sprites overlays reduced the fillrate.
 
@@ -776,11 +776,11 @@ The rain effect is replicated as seen on page \pageref{gg_rain} via the Text lay
 
 Final Fight was released in 1992, three years after the arcade version. Like the Ghouls'n Ghosts port, the game managed to ship on two 5.25-inch 1.2 MiB floppies.
 
-The graphic render uses the same trade off used by Ghouls 'n Ghosts where usage of Tilemap plane is sacrificed in favor of the ability to feed the Sprite layer with tiles. 
+The graphics renderer uses the same trade off used by Ghouls 'n Ghosts where usage of Tilemap plane is sacrificed in favor of the ability to feed the Sprite layer with tiles. 
 
 Two bitmap layers are used for background elements while the Text layer is used for GUI elements. All these layers are rendered in software with a draw cost amortized thanks to hardware scrolling.
 
-The port of Final Fight to X68000 is close to the arcade version but is not considered "perfect" because of missing graphic elements and color discrepancies. 
+The port of Final Fight to X68000 is close to the arcade version but is not considered "perfect" because of missing graphics elements and color discrepancies. 
 
 
 \begin{figure}[H]
@@ -788,7 +788,7 @@ The port of Final Fight to X68000 is close to the arcade version but is not cons
 \caption*{Final Fight on X68000}
 \end{figure}
 
-The number of characters on screen was restricted to 7 which is less than the arcade version where up to 13 where visible. In this case, both the 32 KiB VRAM and the 128 tiles limits were the limiting factor since no multiplexing was possible with free roaming characters.
+The number of characters on screen was restricted to 7 which was less than the arcade version where up to 13 were visible. In this case, both the 32 KiB VRAM and the 128 tiles limits were the limiting factor since no multiplexing was possible with free roaming characters.
 
 The Sprite sandwich trick (page \pageref{finalfight_trick}), where parts of the staircase appear in front of the Sprite is done with a special blending mode were the MSBs gives precedence over the Sprite layer. This leaves 7bpp for the color indexes and the Background ends up using 128 colors instead of 256. In other levels, this blending mode is not used so the Bitmap layers go back to using 8bpp for a total of 256 colors available.
 
@@ -839,11 +839,11 @@ The arcade version called for many sprites tiles, among them two heroes, the min
 
 To manage this problem, developers started by cutting out one minion (blue Jake). 
 
-Since it was still too many tiles, they resorted to enabling (for the intro only) the Tilemap plane. Five out of the six barrels are drawn as tilemap in the Tilemap 0.
+Since it was still too many tiles, they resorted to enabling (for the intro only) the Tilemap plane. Five out of the six barrels are drawn as tilemap in Tilemap 0.
 
 Since a tilemap is a simple grid of tiles with no concept of sprites and overlap, special 8$\times$8 tiles were generated where columns of barrels are pre-overlapped.
 
-Things get messy when animation must occur. To allow the barrels to be broken into pieces, the engine exploits the timing of enemies fleeing. First when Damned leaves, then when Dug retires, rows of barrels are progressively migrated out of the tilemap layer into the sprite layer. 
+Things get messy when animation must occur. To allow the barrels to be broken into pieces, the engine exploits the timing of enemies fleeing. First, when Damned leaves and then when Dug retires, rows of barrels are progressively migrated out of the tilemap layer into the sprite layer. 
 
 
 
@@ -865,7 +865,7 @@ Things get messy when animation must occur. To allow the barrels to be broken in
 
 \vspace{4ex}
 
-The whole trick is not perfect. As the barrels break down, the machine reaches its sprite tile limit. Since the engine is not as elaborated as the arcade version (page \pageref{going_too_far}), a partial Cody is drawn. 
+The whole trick is not perfect. As the barrels break down, the machine reaches its sprite tile limit. Since the engine is not as elaborate as the arcade version (page \pageref{going_too_far}), a partial Cody is drawn. 
 
 \vspace{-4ex}
 \begin{minipage}[t]{0.49\linewidth}
@@ -889,7 +889,7 @@ Street Fighter II Champion Edition was released only a year after the arcade ver
 
 The volume of assets forced the game to ship on four 5.25-inch 1.2 MiB floppies. The game manages to run with 2 MiB of RAM but suffers numerous loading delays when traveling between countries. However, on a machine with 4 MiB the game engine loads all floppies to RAM to provide a loading-free experience.
 
-In terms of GFX rendering architecture, the Tilemaps are once again ignored in favor of the Sprite layer. The floors are software rendered. However the per-line parallax is considerably sped up thanks to the combination of raster effect and hardware scrolling. On each HSYNC event the horizontal hardware offset is adjusted which allows rendering Page 0 once and for all.
+In terms of GFX rendering architecture, the Tilemaps are once again ignored in favor of the Sprite layer. The floors are software rendered. However the per-line parallax is considerably sped up thanks to the combination of raster effects and hardware scrolling. On each HSYNC event the horizontal hardware offset is adjusted which allows rendering Page 0 once and for all.
 
 Some Sprite elements that used to be rendered on the CPS-1 OBJ layer found their way into the Text layer. This layer is not used for GUI but to render decorative sprites (like the statue in Dictator level). It is likely that the 32 KiB was once again not big enough to contain the sprites for both opponents and decorations.
 
@@ -958,7 +958,7 @@ When fighting occurs in China, the Text layer is not used for Sprite decoration 
 
 
 \subsection{Saving Further 68000 Cycles}
-If we look closely at Page 1 and 2, we see that the background is split. The alley is on Page 2 while the rest is on Page 1, which is surprising since no parallax effect exists (they are on the same plane). 
+If we look closely at Page 0 and 1, we see that the background is split. The alley is on Page 2 while the rest is on Page 1, which is surprising since no parallax effect exists (they are on the same plane). 
 
 This reduces overdraw when the Page 1 cyclist crosses the screen and goes over the other cyclist in the back alley, saving a few CPU cycles.
 

--- a/src/prog_z80.tex
+++ b/src/prog_z80.tex
@@ -1,7 +1,7 @@
 \chapter{Sound System}
 Making ROMs for the sound system is a little bit more complicated than for the GFX system. 
 
-Not only are samples and music assets processed, there is also a need to compile code to bootstrap and then run the z80. This program is commonly called a "Sound Driver".
+Not only are samples and music assets processed, there is also a need to compile code to bootstrap and then run on the z80. This program is commonly called a "Sound Driver".
 
 \begin{figure}[H]
 \sdraw{1.0}{sound_arch}
@@ -101,7 +101,7 @@ Notice there is no metadata to indicate the bitrate. The "database" entry is a p
 
 
 \section{Processing Music}
-Making music with FM synthesis is an art which this book does not intend to butcher. The best way to go is to ask the musicians in the team to work with whatever tool they wish (the amazing DefleMask is highly recommended) and export their symphonies using VGM file format.
+Making music with FM synthesis is an art which this book does not intend to butcher. The best way to go is to ask the musicians in the team to work with whatever tool they wish (the amazing DefleMask is highly recommended) and export their symphonies using the VGM file format.
 
 VGM (Video Game Music) is a community effort originating from \icode{smspower.org} to create an audio file format able to support many legacy systems (SEGA consoles, MSX, Neo Geo, and PC) as well as arcade hardware.
 
@@ -180,7 +180,7 @@ The calling functions from ASM to C require using \icode{\_} prefixed symbols.
 
 \subsection{z80 interrupt}
 \index{Interrupts!Programming z80}
-In order to interact with the latches properly but also be able to keep track of wall-time, the z80 needs to be interrupted regularly. Zilog's CPU does features a timer RFSH but it is intended for DRAM refresh (which the sound system does not feature anyway).
+In order to interact with the latches properly but also be able to keep track of wall-time, the z80 needs to be interrupted regularly. Zilog's CPU does feature a timer RFSH but it is intended for DRAM refresh (which the sound system does not feature anyway).
 
 Instead the interrupts are triggered by the YM2151, thanks to its two internal timers. Timer A is a 10-bit counter while Timer B is an 8-bit counter. For a YM2151 running at 3,579Hz, the trigger formula is 64 $\times$ (1024 - value) / 3579.
 
@@ -295,7 +295,7 @@ NEC entered the personal computer market in 1979 with its 8800 series. These mac
 
 Thanks to its optional kanji ROM, NEC quickly gained traction. The PC-88 accounted for 40\% of the Japanese personal market by 1981.
 
-By the mid-80s, the aging series was discontinued in favor of machines based on 16-bit Intel CPUs such as the i286. The NEC's next computer, named 9801, was be the first in the 9800 line. These machines were commonly referred to as "PC-98".
+By the mid-80s, the aging series was discontinued in favor of machines based on 16-bit Intel CPUs such as the i286. NEC's next computer, named 9801, would be the first in the 9800 line. These machines were commonly referred to as "PC-98".
 
 \begin{figure}[H]
 
@@ -327,10 +327,10 @@ Japanese market. NEC's PCs were named after what they were, \textbf{P}ersonal \t
 
 
 \subsubsection{C-Bus}
-The PC-98 uses a proprietary 16-bit C-bus instead of the IBM's ISA bus. BIOS, I/O port addressing, memory management and graphics output are also different. This architecture was both a moat that protected NEC from clone manufacturers (which plagued IBM in the USA) and a dungeon that prevented its machine from benefiting from the many peripherals built for IBM PCs.
+The PC-98 uses a proprietary 16-bit C-bus instead of IBM's ISA bus. BIOS, I/O port addressing, memory management and graphics output are also different. This architecture was both a moat that protected NEC from clone manufacturers (which plagued IBM in the USA) and a dungeon that prevented its machine from benefiting from the many peripherals built for IBM PCs.
 
 
-It was an extra effort for manufactures to create C-bus version of their card but companies such as Roland and Creative did release some of their sound cards for PC-98.
+It was extra effort for manufacturers to create C-bus version of their card but companies such as Roland and Creative did release some of their sound cards for PC-98.
 
 \begin{figure}[H]
 
@@ -341,9 +341,9 @@ It was an extra effort for manufactures to create C-bus version of their card bu
 
 
 \subsubsection{Video chip}
-Besides their proprietary bus, PC-98s were noteworthy for their, at the time, powerful graphic system.
+Besides their proprietary bus, PC-98s were noteworthy for their, at the time, powerful graphics system.
 
-The heart of it was the High-Performance Graphics Display Controller 7220, more commonly known as $\upmu$PD7220. The PC-98 used two of them, both running 2.5MHz. One handled the 8 KiB VRAM for text while the other acted as a co-processor managing a 96 KiB VRAM framebuffer.
+The heart of it was the High-Performance Graphics Display Controller 7220, more commonly known as $\upmu$PD7220. The PC-98 used two of them, both running at 2.5MHz. One handled the 8 KiB VRAM for text while the other acted as a co-processor managing a 96 KiB VRAM framebuffer.
 
 The tandem was one of the first GPUs, presenting primitives to draw lines, circles, arcs, and character graphics. In its highest resolution mode the PC-98 reached an impressive 640×400 with 8 colors. It allowed Latin alphabetic, numeric and most importantly katakana characters. An optional ROM board added 3,000 kanji glyphs to the repertory.   
 

--- a/src/prog_z80.tex
+++ b/src/prog_z80.tex
@@ -330,7 +330,7 @@ Japanese market. NEC's PCs were named after what they were, \textbf{P}ersonal \t
 The PC-98 uses a proprietary 16-bit C-bus instead of IBM's ISA bus. BIOS, I/O port addressing, memory management and graphics output are also different. This architecture was both a moat that protected NEC from clone manufacturers (which plagued IBM in the USA) and a dungeon that prevented its machine from benefiting from the many peripherals built for IBM PCs.
 
 
-It was extra effort for manufacturers to create C-bus version of their card but companies such as Roland and Creative did release some of their sound cards for PC-98.
+It was extra effort for manufacturers to create a C-bus version of their card but companies such as Roland and Creative did release some of their sound cards for PC-98.
 
 \begin{figure}[H]
 

--- a/src/programing.tex
+++ b/src/programing.tex
@@ -20,9 +20,9 @@ Other dependencies are more convoluted. The \icode{.wav} sample files for exampl
 
 Likewise, the \icode{.png} files containing artwork are transformed to indexed format before making their way to the GFX ROM. They also require generating a \icode{.h} header file, this time containing tileID. Additionally, a \icode{.c} file containing each tile palette is generated in order to be compiled into the 68000 ROM. 
 
-An even more complicated graph emerges from the music \icode{.vgm} files. The music track contains YM2151 commands that must be transformed in bytecode, stored in a \icode{.c} file, and compiled along with the z80 code. To be referenced, a header file containing music ID must also be generated and compiled with the 68000 ROM. Music is also embellished with audio samples which must also be compressed to ADPCM and added to the OKI ROM.
+An even more complicated graph emerges from the music \icode{.vgm} files. The music track contains YM2151 commands that must be transformed in bytecode, stored in a \icode{.c} file, and compiled along with the z80 code. To be referenced, a header file containing music IDs must also be generated and compiled with the 68000 ROM. Music is also embellished with audio samples which must also be compressed to ADPCM and added to the OKI ROM.
 
-To complicate things even further, each of the four ROM mentioned must use different \icode{WORD} size and interleaving across the chips containing it.
+To complicate things even further, each of the four ROMs mentioned must use a different \icode{WORD} size and interleaving across the chips containing it.
 
 \section{CCPS: The CPS-1 Build System}
 As this book was being written, several tools were authored to validate the understanding of the hardware.
@@ -138,9 +138,9 @@ In a game like Street Fighter II, developers took the approach of not giving val
 
 
 
-When interrupted, the z80 reads the byte in latch 1 and appends it into a circular buffer. Interpretation happens in the "main" thread. A byte value \icode{FE} means that the next byte is the ID of a music that should start playback. 
+When interrupted, the z80 reads the byte in latch 1 and appends it into a circular buffer. Interpretation happens in the "main" thread. A byte value \icode{FE} means that the next byte is the ID of a music track that should start playback. 
 
-Otherwise the value is a sound ID to be played immediately on the OKI. This scheme wastes a single byte value to overhead. It allows for 256 music IDs and 254 samples IDs.
+Otherwise the value is a sound ID to be played immediately on the OKI. This scheme wastes a single byte value to overhead. It allows for 256 music IDs and 254 sample IDs.
 
  \begin{figure}[H]
 \nbdraw{latches_interface}
@@ -159,9 +159,9 @@ The "sound driver" kept on evolving, sometimes changing drastically even between
 
 In Final Fight, a sound ID received for playback is directly forwarded to the OKI. In Street Fighter II, a translation table is used. The ID received is an index into an array containing the actual OKI ID along with the channel and volume to use.
 
-The merits of a translation table may be explained by the size of Capcom team and the inability to do a "full build" easily at the time.
+The merits of a translation table may be explained by the size of the Capcom team and the inability to do a "full build" easily at the time.
 
-If the sound team had to change the OKI layout, all IDS used by the m68k would be invalid. With a translation table, the sound team was able to make any change they wanted and keep their sound and music IDs backward compatible.
+If the sound team had to change the OKI layout, all IDs used by the m68k would be invalid. With a translation table, the sound team was able to make any change they wanted and keep their sound and music IDs backwards compatible.
 
 
 \subsection{Our sound driver}
@@ -172,7 +172,7 @@ The sound driver described in the next pages uses the same architecture as Capco
 
 The communication protocol however is not streamed. Whereas it is more powerful, it is also much more complicated. For simplicity, a byte is immediately interpreted without the need to rebuild a stream.
 
-The byte space is divided in two. If the MSB is set to one (\icode{0x80}) it is a request for sound effect playback and if the MSB is set to zero \icode{0x00} it indicates a music playback. 
+The byte space is divided in two. If the MSB is set to one (\icode{0x80}) it is a request for sound effect playback and if the MSB is set to zero \icode{0x00} it indicates music playback. 
 
 This leaves "only" 126 sound values and 127 music values but is more than enough for the intended purpose. Volume is hard-coded and round-robin rotation is used to pick between channels 1 or 2 to serve a request. 
 
@@ -185,7 +185,7 @@ The m68k tracks time in units of 16ms while the z80 can do the same in increment
 
 
 \section{Randomness}
-Pseudo-random series of numbers can be achieved using Maximum-Length LFSRs (Linear Feedback Shift Register). On the m68k, a 32-bit registers will give 4,194,304 different values before repeating itself. On the z80, the 8-bit register will only provide 256 values.
+Pseudo-random series of numbers can be achieved using Maximum-Length LFSRs (Linear Feedback Shift Register). On the m68k, the 32-bit registers will give 4,194,304 different values before repeating itself. On the z80, the 8-bit register will only provide 256 values.
 
 The only tricky part is to pick a seed to initialize the register. Street Fighter 2 uses the frame counter while other titles read the content of the CPU register during bootstrap. The latter method does not work well when working with emulators (they usually initialize their registers to zero) and should be avoided.
 

--- a/src/programing.tex
+++ b/src/programing.tex
@@ -159,7 +159,7 @@ The "sound driver" kept on evolving, sometimes changing drastically even between
 
 In Final Fight, a sound ID received for playback is directly forwarded to the OKI. In Street Fighter II, a translation table is used. The ID received is an index into an array containing the actual OKI ID along with the channel and volume to use.
 
-The merits of a translation table may be explained by the size of the Capcom team and the inability to do a "full build" easily at the time.
+The merits of a translation table may be explained by the size of Capcom's team and the inability to do a "full build" easily at the time.
 
 If the sound team had to change the OKI layout, all IDs used by the m68k would be invalid. With a translation table, the sound team was able to make any change they wanted and keep their sound and music IDs backwards compatible.
 


### PR DESCRIPTION
Fix various typos and grammatical errors from the 2nd half of the book (starting at pg. 121) to the end of the book. I noticed these while reading an older, physical copy of the book. I did not start recording errors I noticed till the 2nd half the book (I may go back and do the first 120 pages as well). Page 187 I slightly re-worded the sentence talking about the gcc compiler, as assembler, and ld linker because the changes pushed the word "instructions" onto a separate page.

Changes have been made on the following pages in the 2nd half of the book:
- pg. 121
- pg. 132
- pg. 138
- pg. 139
- pg. 140
- pg. 141
- pg. 167
- pg. 173
- pg. 176
- pg. 183
- pg. 185
- pg. 187
- pg. 189
- pg. 190
- pg. 198
- pg. 203
- pg. 210
- pg. 212
- pg. 214
- pg. 218
- pg. 219
- pg. 220